### PR TITLE
Fix main in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fancybox",
   "version": "2.1.6",
   "description": "fancyBox is a tool that offers a nice and elegant way to add zooming functionality for images, html content and multi-media on your webpages. It is built on the top of the popular JavaScript framework jQuery and is both easy to implement and a snap to customize.",
-  "main": "./dist/fancybox.jquery.cjs.js",
+  "main": "./dist/jquery.fancybox.cjs.js",
   "scripts": {
     "test": "./node_modules/phantomjs/lib/phantom/bin/phantomjs ./test.js"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fancybox",
   "version": "2.1.6",
   "description": "fancyBox is a tool that offers a nice and elegant way to add zooming functionality for images, html content and multi-media on your webpages. It is built on the top of the popular JavaScript framework jQuery and is both easy to implement and a snap to customize.",
-  "main": "./dist/jquery.fancybox.cjs.js",
+  "main": "dist/js/jquery.fancybox.cjs.js",
   "scripts": {
     "test": "./node_modules/phantomjs/lib/phantom/bin/phantomjs ./test.js"
   },


### PR DESCRIPTION
`main` currently points to the incorrect location / name for the main file for the module, so browserify cannot find the module.

This PR fixes that and makes it possible to `require('fancybox)($)` using npm and browserify.
