### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-fancyBox
+fancyBox (deprecated)
 ========
+
+**WARNING: This fork is deprecated. Please head over to https://www.npmjs.com/package/@fancyapps/fancybox for the official version**
 
 fancyBox is a tool that offers a nice and elegant way to add zooming functionality for images, html content and multi-media on your webpages.
 


### PR DESCRIPTION
@olsonpm, would you consider adding this note and publishing it to the registry? We just lost some time on a project because we accidentally installed this package instead of the official one and couldn't immediately figure out why the official documentation and didn't apply to our implementation. Ideally, this would be combined with https://docs.npmjs.com/cli/deprecate

No hard feelings, I'm sure this package served a purpose at some point.

Thanks!